### PR TITLE
Add registry:insert()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Method `View:patch()`.
 - Method `Registry:find()`.
+- Method `Registry:insert()`
 - Overload `ecr.queue()` to accept a function connector.
 - Function `ecr.buffer_to_buffer()`.
 

--- a/src/ecr.luau
+++ b/src/ecr.luau
@@ -114,6 +114,7 @@ export type Registry = {
     has_none: (self: Registry, id: entity) -> boolean,
     add: <T...>(self: Registry, id: entity, T...) -> (),
     set: <T>(self: Registry, id: entity, ctype: T, value: T) -> (),
+    insert: <T>(self: Registry, id: entity, ctype: Array<T>, value: T) -> (),
     patch: <T>(self: Registry, id: entity, ctype: T, fn: ((T) -> T)?) -> T,
     has: <T...>(self: Registry, id: entity, T...) -> boolean,
     get: <T...>(self: Registry, id: entity, T...) -> T...,
@@ -1797,6 +1798,26 @@ local function registry_create(): Registry
             ASSERT(ctype_is_tag(ctype), "cannot set component value to nil")
             if idx_ver ~= ID_NULL then return end
             POOL_ADD_ID(pool, id)
+        end
+    end
+
+    function registry.insert<T>(self: Registry, id: entity, ctype: Array<T>, value: T)
+        local pool = STORAGE(ctype)
+
+        local key = ID_KEY(id)
+        POOL_RESIZE_MAP_IF_NEEDED(pool, key)
+        local idx_ver = BUFFER_GET(pool.map, key)
+
+        if idx_ver ~= ID_NULL then
+            ID_ASSERT_VERSION_EQUAL(idx_ver, id)
+            local idx = ID_KEY(idx_ver)
+            local t = ARRAY_GET(pool.values, idx)
+            table.insert(t, value)
+            if pool.on_change then fire(pool.on_change, id, t) end
+        else
+            ASSERT_VALID_ENTITY(id)
+            local t = {value}
+            POOL_ADD(pool, id, t)
         end
     end
     

--- a/test/benchmarks.luau
+++ b/test/benchmarks.luau
@@ -245,6 +245,48 @@ do TITLE "set"
     end
 end
 
+do TITLE "insert"
+
+    BENCH("insert new array", function()
+        local reg = REG_INIT(N)
+        local ids = table.create(N)
+
+        for i = 1, N do
+            local e = reg:create()
+            ids[i] = e
+        end
+
+        for i = 1, START(N) do
+            reg:insert(ids[i], A, true)
+        end
+    end)
+
+    BENCH("insert new value", function()
+        local reg = REG_INIT(N)
+        local ids = table.create(N)
+
+        for i = 1, N do
+            local e = reg:create()
+            reg:insert(e, A, true)
+            ids[i] = e
+        end
+
+        for i = 1, START(N) do
+            reg:insert(ids[i], A, true)
+        end
+    end)
+
+    BENCH("insert new value to same entity", function()
+        local reg = REG_INIT(N)
+        local id = reg:create()
+
+        for i = 1, START(N) do
+            reg:insert(id, A, true)
+        end
+    end)
+
+end
+
 do TITLE "patch"
     local function setup()
         local reg = REG_INIT(N)

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -621,6 +621,30 @@ TEST("registry:has()", function()
     end
 end)
 
+TEST("registry:insert()", function()
+    local ARRAY = ecr.component() :: {number}
+    local reg = ecr.registry()
+    local id = reg:create()
+    
+    do CASE "insert adds array if no value"
+        reg:insert(id, ARRAY, 1)
+
+        CHECK(reg:has(id, ARRAY))
+        CHECK(type(reg:get(id, ARRAY)) == "table")
+        CHECK(reg:get(id, ARRAY)[1] == 1)
+    end
+
+    do CASE "insert adds values to the end"
+        reg:insert(id, ARRAY, 2)
+
+        CHECK(reg:has(id, ARRAY))
+        CHECK(type(reg:get(id, ARRAY)) == "table")
+        CHECK(reg:get(id, ARRAY)[1] == 1)
+        CHECK(reg:get(id, ARRAY)[2] == 2)
+    end
+
+end)
+
 TEST("registry:patch()", function()
     local reg = ecr.registry()
 


### PR DESCRIPTION
Adds `registry:insert()` to ECR

This makes certain patterns significantly easier like queuing damage / hits and effects.